### PR TITLE
Add themed PrimeVue login page with dark mode toggle

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,30 +1,451 @@
 <script setup lang="ts">
-import HelloWorld from './components/HelloWorld.vue'
+import { onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
+
+type LoginForm = {
+  username: string
+  password: string
+  remember: boolean
+}
+
+type FormErrors = {
+  username: string
+  password: string
+}
+
+const STORAGE_KEY = 'app-theme'
+
+const form = reactive<LoginForm>({
+  username: '',
+  password: '',
+  remember: true,
+})
+
+const errors = reactive<FormErrors>({
+  username: '',
+  password: '',
+})
+
+const isSubmitting = ref(false)
+const submitted = ref(false)
+const isDarkMode = ref(false)
+
+let mediaQuery: MediaQueryList | null = null
+
+const updateTheme = (value: boolean, persist = true) => {
+  if (typeof document === 'undefined') {
+    return
+  }
+
+  const root = document.documentElement
+  root.classList.toggle('dark', value)
+
+  if (persist && typeof window !== 'undefined') {
+    window.localStorage.setItem(STORAGE_KEY, value ? 'dark' : 'light')
+  }
+}
+
+const handleSystemThemeChange = (event: MediaQueryListEvent) => {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  const stored = window.localStorage.getItem(STORAGE_KEY)
+  if (!stored) {
+    isDarkMode.value = event.matches
+    updateTheme(event.matches, false)
+  }
+}
+
+onMounted(() => {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  const stored = window.localStorage.getItem(STORAGE_KEY)
+
+  if (stored) {
+    isDarkMode.value = stored === 'dark'
+  } else if (window.matchMedia) {
+    mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+    isDarkMode.value = mediaQuery.matches
+  }
+
+  updateTheme(isDarkMode.value, false)
+
+  if (!mediaQuery && window.matchMedia) {
+    mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+  }
+
+  mediaQuery?.addEventListener('change', handleSystemThemeChange)
+})
+
+onBeforeUnmount(() => {
+  mediaQuery?.removeEventListener('change', handleSystemThemeChange)
+})
+
+watch(isDarkMode, (value) => {
+  submitted.value = false
+  updateTheme(value)
+})
+
+watch(
+  () => form.username,
+  () => {
+    if (errors.username) {
+      errors.username = ''
+    }
+  },
+)
+
+watch(
+  () => form.password,
+  () => {
+    if (errors.password) {
+      errors.password = ''
+    }
+  },
+)
+
+const validate = () => {
+  errors.username = form.username.trim() ? '' : 'Введите логин'
+  errors.password = form.password ? '' : 'Введите пароль'
+  return !errors.username && !errors.password
+}
+
+const onSubmit = () => {
+  submitted.value = false
+
+  if (!validate()) {
+    return
+  }
+
+  isSubmitting.value = true
+
+  setTimeout(() => {
+    isSubmitting.value = false
+    submitted.value = true
+  }, 800)
+}
 </script>
 
 <template>
-  <div>
-    <a href="https://vite.dev" target="_blank">
-      <img src="/vite.svg" class="logo" alt="Vite logo" />
-    </a>
-    <a href="https://vuejs.org/" target="_blank">
-      <img src="./assets/vue.svg" class="logo vue" alt="Vue logo" />
-    </a>
+  <div class="auth-page">
+    <div class="auth-card">
+      <div class="theme-toggle">
+        <label class="theme-toggle__label" for="theme-switch">{{ isDarkMode ? 'Темный режим' : 'Светлый режим' }}</label>
+        <InputSwitch v-model="isDarkMode" inputId="theme-switch" aria-label="Переключить тему" />
+      </div>
+
+      <Card class="login-card">
+        <template #title>
+          <div class="card-header">
+            <div class="card-icon" aria-hidden="true">🔐</div>
+            <div>
+              <h2>Вход в систему</h2>
+              <p>Введите логин и пароль, чтобы получить доступ к платформе.</p>
+            </div>
+          </div>
+        </template>
+        <template #content>
+          <form class="login-form" @submit.prevent="onSubmit">
+            <div class="form-field">
+              <label class="form-label" for="username">Логин</label>
+              <InputText
+                id="username"
+                v-model.trim="form.username"
+                autocomplete="username"
+                placeholder="Введите логин"
+                class="w-full"
+              />
+              <small v-if="errors.username" class="form-error">{{ errors.username }}</small>
+            </div>
+
+            <div class="form-field">
+              <label class="form-label" for="password">Пароль</label>
+              <Password
+                id="password"
+                v-model="form.password"
+                toggleMask
+                :feedback="false"
+                autocomplete="current-password"
+                placeholder="Введите пароль"
+                class="w-full"
+                inputClass="w-full"
+              />
+              <small v-if="errors.password" class="form-error">{{ errors.password }}</small>
+            </div>
+
+            <div class="form-footer">
+              <div class="remember">
+                <Checkbox v-model="form.remember" inputId="remember" :binary="true" />
+                <label for="remember">Запомнить меня</label>
+              </div>
+              <a class="link" href="#">Забыли пароль?</a>
+            </div>
+
+            <Button type="submit" label="Войти" class="submit-button" :loading="isSubmitting" />
+          </form>
+
+          <p v-if="submitted" class="success-message">
+            Добро пожаловать обратно, {{ form.username || 'пользователь' }}!
+          </p>
+        </template>
+      </Card>
+
+      <Divider align="center" type="solid">
+        <span>или</span>
+      </Divider>
+
+      <div class="helper-text">
+        <p>
+          Еще нет аккаунта?
+          <a class="link" href="#">Создать учетную запись</a>
+        </p>
+      </div>
+    </div>
   </div>
-  <HelloWorld msg="Vite + Vue" />
 </template>
 
 <style scoped>
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
+.auth-page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1.5rem, 5vw, 3rem);
+  transition: background 0.4s ease, color 0.4s ease;
 }
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
+
+.auth-card {
+  width: min(460px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
 }
-.logo.vue:hover {
-  filter: drop-shadow(0 0 2em #42b883aa);
+
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  color: var(--text-color-secondary);
+  font-size: 0.9rem;
+}
+
+.theme-toggle__label {
+  font-weight: 600;
+}
+
+:deep(.theme-toggle .p-inputswitch) {
+  scale: 0.95;
+}
+
+:deep(.theme-toggle .p-inputswitch .p-inputswitch-slider) {
+  background: rgba(41, 67, 161, 0.35);
+}
+
+html.dark :deep(.theme-toggle .p-inputswitch .p-inputswitch-slider) {
+  background: rgba(91, 120, 255, 0.35);
+}
+
+:deep(.theme-toggle .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider) {
+  background: var(--primary-color);
+}
+
+:deep(.login-card.p-card) {
+  background: var(--surface-card);
+  border: 1px solid var(--surface-border);
+  border-radius: 1.5rem;
+  box-shadow: 0 22px 45px rgba(22, 34, 79, 0.18);
+  color: var(--text-color);
+}
+
+:deep(.login-card .p-card-body) {
+  padding: clamp(1.75rem, 5vw, 2.5rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: var(--text-color);
+}
+
+.card-header h2 {
+  margin: 0;
+  font-size: clamp(1.4rem, 3.6vw, 1.75rem);
+  font-weight: 700;
+}
+
+.card-header p {
+  margin: 0.35rem 0 0;
+  font-size: 0.95rem;
+  color: var(--text-color-secondary);
+}
+
+.card-icon {
+  width: 3rem;
+  height: 3rem;
+  display: grid;
+  place-items: center;
+  border-radius: 1rem;
+  font-size: 1.4rem;
+  background: linear-gradient(135deg, rgba(41, 67, 161, 0.12), rgba(91, 120, 255, 0.35));
+}
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.form-label {
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+:deep(.p-inputtext),
+:deep(.p-password .p-inputtext) {
+  width: 100%;
+  background: var(--surface-section);
+  border: 1px solid var(--surface-border);
+  border-radius: 0.85rem;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  color: var(--text-color);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+:deep(.p-inputtext:focus),
+:deep(.p-password .p-inputtext:focus) {
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary-color) 25%, transparent);
+}
+
+:deep(.p-password) {
+  width: 100%;
+}
+
+.form-error {
+  margin-top: 0.25rem;
+  color: #f87171;
+  font-size: 0.8rem;
+}
+
+.form-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+  color: var(--text-color-secondary);
+}
+
+.remember {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+:deep(.p-checkbox .p-checkbox-box) {
+  width: 1.1rem;
+  height: 1.1rem;
+  border-radius: 0.4rem;
+  border: 1px solid var(--surface-border);
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+:deep(.p-checkbox.p-highlight .p-checkbox-box) {
+  border-color: var(--primary-color);
+  background: var(--primary-color);
+}
+
+:deep(.p-checkbox .p-checkbox-box .p-checkbox-icon) {
+  font-size: 0.7rem;
+}
+
+.submit-button {
+  width: 100%;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+:deep(.submit-button.p-button) {
+  padding-block: 0.85rem;
+  border-radius: 0.9rem;
+  background: var(--primary-color);
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+:deep(.submit-button.p-button:hover) {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 20px rgba(41, 67, 161, 0.22);
+}
+
+:deep(.submit-button.p-button:focus-visible) {
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--primary-color) 35%, transparent);
+}
+
+.link {
+  color: var(--primary-color);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.link:hover {
+  text-decoration: underline;
+}
+
+.success-message {
+  margin: 1rem 0 0;
+  padding: 0.75rem 1rem;
+  border-radius: 0.85rem;
+  background: color-mix(in srgb, var(--primary-color) 16%, transparent);
+  color: var(--text-color);
+  font-weight: 600;
+  text-align: center;
+}
+
+:deep(.p-divider-horizontal) {
+  margin: 0;
+  border-color: var(--surface-border);
+}
+
+:deep(.p-divider .p-divider-content) {
+  padding: 0 1rem;
+  color: var(--text-color-secondary);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.helper-text {
+  text-align: center;
+  color: var(--text-color-secondary);
+  font-size: 0.95rem;
+}
+
+@media (max-width: 560px) {
+  .auth-card {
+    width: 100%;
+  }
+
+  :deep(.login-card .p-card-body) {
+    padding: 1.5rem;
+  }
+
+  .form-footer {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }
 </style>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,34 @@
-import {createApp} from 'vue'
-import './style.css'
+import { createApp } from 'vue'
 import App from './App.vue'
-import PrimeVue from 'primevue/config';
-import Aura from '@primeuix/themes/aura';
+import PrimeVue from 'primevue/config'
+import Aura from '@primeuix/themes/aura'
+import Button from 'primevue/button'
+import Card from 'primevue/card'
+import Checkbox from 'primevue/checkbox'
+import Divider from 'primevue/divider'
+import InputSwitch from 'primevue/inputswitch'
+import InputText from 'primevue/inputtext'
+import Password from 'primevue/password'
+import './style.css'
 
-createApp(App)
-    .use(PrimeVue, {
-        theme: {
-            preset: Aura
-        }
-    })
-    .mount('#app')
+const app = createApp(App)
+
+app.use(PrimeVue, {
+  ripple: true,
+  theme: {
+    preset: Aura,
+    options: {
+      darkModeSelector: 'html.dark',
+    },
+  },
+})
+
+app.component('Button', Button)
+app.component('Card', Card)
+app.component('Checkbox', Checkbox)
+app.component('Divider', Divider)
+app.component('InputSwitch', InputSwitch)
+app.component('InputText', InputText)
+app.component('Password', Password)
+
+app.mount('#app')

--- a/src/style.css
+++ b/src/style.css
@@ -1,79 +1,142 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
+  color-scheme: light;
+  --primary-color: #2943a1;
+  --primary-color-contrast: #ffffff;
+  --primary-color-hover: #3b58d9;
+  --primary-color-active: #1c2f6e;
+  --surface-ground: #e8ecff;
+  --surface-section: #f6f7ff;
+  --surface-card: #ffffff;
+  --surface-border: rgba(34, 63, 147, 0.18);
+  --text-color: #15204d;
+  --text-color-secondary: #4b5a88;
+  --focus-ring: color-mix(in srgb, var(--primary-color) 35%, transparent);
+  background-color: var(--surface-ground);
+  color: var(--text-color);
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+html.dark {
+  color-scheme: dark;
+  --primary-color: #5b78ff;
+  --primary-color-contrast: #0b1435;
+  --primary-color-hover: #6d87ff;
+  --primary-color-active: #445bdb;
+  --surface-ground: #050b1d;
+  --surface-section: #0c152c;
+  --surface-card: #111f3f;
+  --surface-border: rgba(91, 120, 255, 0.28);
+  --text-color: #f2f6ff;
+  --text-color-secondary: #bcc8ff;
+  --focus-ring: color-mix(in srgb, var(--primary-color) 45%, transparent);
+  background-color: var(--surface-ground);
+  color: var(--text-color);
 }
 
+html,
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
   min-height: 100vh;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+body {
+  background: radial-gradient(120% 120% at 50% 0%, rgba(44, 71, 171, 0.35) 0%, rgba(15, 24, 64, 0) 55%),
+    var(--surface-ground);
+  transition: background-color 0.4s ease, color 0.4s ease, background 0.4s ease;
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
 }
 
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+html.dark body {
+  background: radial-gradient(120% 120% at 50% 0%, rgba(91, 120, 255, 0.32) 0%, rgba(5, 11, 29, 0) 55%),
+    var(--surface-ground);
 }
 
-.card {
-  padding: 2em;
+* {
+  box-sizing: border-box;
+}
+
+a {
+  color: inherit;
+}
+
+a:hover {
+  text-decoration: none;
 }
 
 #app {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  flex: 1;
+  min-height: 100vh;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+/* PrimeVue overrides */
+.p-button {
+  background: var(--primary-color);
+  border-color: transparent;
+  color: var(--primary-color-contrast);
+}
+
+.p-button:enabled:hover {
+  background: var(--primary-color-hover);
+}
+
+.p-button:enabled:active {
+  background: var(--primary-color-active);
+}
+
+.p-button:focus-visible {
+  box-shadow: 0 0 0 4px var(--focus-ring);
+}
+
+.p-inputtext,
+.p-password .p-inputtext {
+  border-radius: 0.85rem;
+  border: 1px solid var(--surface-border);
+  background: var(--surface-section);
+  color: var(--text-color);
+}
+
+.p-inputtext:focus,
+.p-password .p-inputtext:focus {
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.p-card {
+  background: var(--surface-card);
+  color: var(--text-color);
+}
+
+.p-divider.p-divider-horizontal:before {
+  border-color: var(--surface-border);
+}
+
+.p-divider .p-divider-content {
+  background: transparent;
+}
+
+.p-checkbox .p-checkbox-box {
+  border: 1px solid var(--surface-border);
+}
+
+.p-checkbox.p-highlight .p-checkbox-box {
+  background: var(--primary-color);
+  border-color: var(--primary-color);
+}
+
+.p-inputswitch.p-inputswitch-checked .p-inputswitch-slider {
+  background: var(--primary-color);
+}
+
+.p-password-panel {
+  background: var(--surface-card);
+  border: 1px solid var(--surface-border);
+  color: var(--text-color);
 }


### PR DESCRIPTION
## Summary
- replace the starter content with a PrimeVue-based login form featuring validation and status messaging
- add a dark-mode toggle that syncs with system preference and stores the user choice
- customize global styles to deliver a dark blue theme with matching PrimeVue overrides

## Testing
- `npm run build` *(fails: missing PrimeVue packages in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc549d99d08326bf503ce699c3cd57